### PR TITLE
Add markdown page generation for LLM-friendly site access

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ fs.readdir(articleSrc, (error, yearDirs) => {
   const rssItems = [];
   let isRssBuilt = false;
 
-  // first pass: collect all article metadata for markdown generation
+  // first pass: collect all article metadata and parsed content
   yearDirs.forEach((yearDir) => {
     const articleSrcYearDir = path.join(articleSrc, yearDir);
     const files = fs.readdirSync(articleSrcYearDir);
@@ -136,19 +136,30 @@ fs.readdir(articleSrc, (error, yearDirs) => {
       );
       const description = pageData.attributes.description || '';
 
+      // truncate at word boundary
+      let shortDescription = description;
+      if (description.length > 120) {
+        shortDescription = description.substring(0, 120);
+        const lastSpace = shortDescription.lastIndexOf(' ');
+        if (lastSpace > 80) {
+          shortDescription = shortDescription.substring(0, lastSpace);
+        }
+        shortDescription += '...';
+      }
+
       allArticles[yearDir].push({
         title: pageData.attributes.title,
         date: pageData.attributes.date,
         dateString,
         image: pageData.attributes.image,
         description,
-        shortDescription: description.length > 120
-          ? description.substring(0, 120) + '...'
-          : description,
+        shortDescription,
         markdownBody: pageData.body,
+        parsedBody: marked.parse(pageData.body, { pedantic: true }),
         mdFileName,
         yearDir,
         file,
+        keywords: pageData.attributes.keywords,
       });
     });
 
@@ -165,176 +176,154 @@ fs.readdir(articleSrc, (error, yearDirs) => {
   // generate markdown pages
   renderMarkdownPages(yearDirs, navigationItems, mostRecentYear);
 
-  // loop over year named directories
-  yearDirs.forEach((yearDir, yearIndex) => {
-    const articleSrcYearDir = path.join(articleSrc, yearDir);
+  // loop over year named directories, reusing parsed data from first pass
+  yearDirs.forEach((yearDir) => {
+    const articles = allArticles[yearDir];
 
     let yearCollection = [];
 
-    // read files from year directory
-    fs.readdir(articleSrcYearDir, (error, files) => {
-      if (error) throw error;
+    debug('Prepare navigation');
+    data.site.navigationItems = navigationItems.map((year) => {
+      let { URL, name } = year;
+      return {
+        URL,
+        name,
+        active: year.name === yearDir,
+      };
+    });
 
-      debug('Prepare navigation');
-      data.site.navigationItems = navigationItems.map((year) => {
-        let { URL, name } = year;
-        return {
-          URL,
-          name,
-          active: year.name === yearDir,
-        };
-      });
+    // process articles using cached parsed data
+    articles.forEach((cached, index) => {
+      // apply some magic to filenames
+      const fileName = cached.file.replace(/ /g, '+').replace('md', 'html');
+      const fileURI = encodeURIComponent(cached.file)
+        .replace(/%20/g, '+')
+        .replace('md', 'html');
 
-      // process markdown files
-      files.forEach((file, index) => {
-        if (file.startsWith('_')) {
-          return;
-        }
-        const articleFileMd = path.join(articleSrcYearDir, file);
+      // populate basic article data object
+      const ejsArticleData = {
+        article: {
+          index,
+          isSingle: true,
+          title: cached.title,
+          pageTitle: `${cached.title} ${config.titleSuffix}`,
+          image: cached.image,
+          imageName: cached.image.replace(/\..*$/, ''),
+          baseUrl: data.site.baseUrl,
+          titleId: `${cached.title}`.replace(/\s+/g, '_'),
+          permaLink: `${data.site.baseUrl}/${yearDir}/${fileURI}`,
+          content: cached.parsedBody,
+          date: cached.date,
+          pubDate: cached.date,
+          dateString: cached.dateString,
+          license: data.channel.license,
+          keywords: cached.keywords || config.metaKeywords,
+          description: cached.description || config.metaDescription,
+        },
+      };
 
-        const articleMd = fs.readFileSync(articleFileMd, 'utf8');
+      // add last 5 articles to rssItems list
+      if (rssItems.length < 5) {
+        rssItems.push({ ...ejsArticleData.article });
+      }
+      if (rssItems.length === 5 && !isRssBuilt) {
+        renderRssFeed(rssItems, data);
+        isRssBuilt = true;
+      }
 
-        // read meta data from markdown document
-        const pageData = frontMatter(articleMd);
+      // process article template
+      ejs.renderFile(
+        './layout/partials/article.ejs',
+        ejsArticleData,
+        {},
+        (error, resultHTML) => {
+          if (error) throw error;
 
-        // render markdown into HTML
-        const rendered = marked.parse(pageData.body, { pedantic: true });
+          const ejsPageData = Object.assign({}, data);
+          ejsPageData.body = resultHTML;
+          ejsPageData.article = ejsArticleData.article;
 
-        // apply some magic to filenames
-        const fileName = file.replace(/ /g, '+').replace('md', 'html');
-        const fileURI = encodeURIComponent(file)
-          .replace(/%20/g, '+')
-          .replace('md', 'html');
+          debug('Rendered article for permaLink');
 
-        // populate basic article data object
-        const ejsArticleData = {
-          article: {
-            index,
-            isSingle: true,
-            title: pageData.attributes.title,
-            pageTitle: `${pageData.attributes.title} ${config.titleSuffix}`,
-            image: pageData.attributes.image,
-            imageName: pageData.attributes.image.replace(/\..*$/, ''),
-            baseUrl: data.site.baseUrl,
-            titleId: `${pageData.attributes.title}`.replace(/\s+/g, '_'),
-            permaLink: `${data.site.baseUrl}/${yearDir}/${fileURI}`,
-            content: rendered,
-            date: pageData.attributes.date,
-            pubDate: pageData.attributes.date,
-            dateString: new Date(pageData.attributes.date).toLocaleString(
-              'nl-NL',
-              DATE_FORMATTER
-            ),
-            license: data.channel.license,
-            keywords: pageData.attributes.keywords || config.metaKeywords,
-            description:
-              pageData.attributes.description || config.metaDescription,
-          },
-        };
+          ejs.renderFile(
+            './layout/master.ejs',
+            ejsPageData,
+            {},
+            (error, pageHTML) => {
+              if (error) throw error;
 
-        // add last 5 articles to rssItems list
-        if (rssItems.length < 5) {
-          rssItems.push({ ...ejsArticleData.article });
-        }
-        if (rssItems.length === 5 && !isRssBuilt) {
-          renderRssFeed(rssItems, data);
-          isRssBuilt = true;
-        }
+              const yearDirName = `${destPath}/${yearDir}`;
 
-        // process article template
-        ejs.renderFile(
-          './layout/partials/article.ejs',
-          ejsArticleData,
-          {},
-          (error, resultHTML) => {
-            if (error) throw error;
-
-            const ejsPageData = Object.assign({}, data);
-            ejsPageData.body = resultHTML;
-            ejsPageData.article = ejsArticleData.article;
-
-            debug('Rendered article for permaLink');
-
-            ejs.renderFile(
-              './layout/master.ejs',
-              ejsPageData,
-              {},
-              (error, pageHTML) => {
-                if (error) throw error;
-
-                const yearDirName = `${destPath}/${yearDir}`;
-
-                fse.mkdirsSync(yearDirName);
-                fs.writeFile(
-                  path.join(yearDirName, fileName),
-                  pageHTML,
-                  fsWriteCallback(`Wrote HTML for ${file}`)
-                );
-              }
-            );
-          }
-        );
-
-        ejsArticleData.article.isSingle = false;
-
-        // process article template for year overview page
-        ejs.renderFile(
-          './layout/partials/article.ejs',
-          ejsArticleData,
-          {},
-          (error, resultHTML) => {
-            if (error) throw error;
-
-            yearCollection.push([
-              ejsArticleData.article.date,
-              resultHTML,
-              ejsArticleData.article.image,
-            ]);
-            debug('Rendered article for year archive');
-          }
-        );
-      });
-
-      if (yearCollection.length) {
-        let ejsPageData = Object.assign({}, data);
-        yearCollection = yearCollection
-          .sort((a, b) => {
-            let dateA = new Date(a[0]).getTime();
-            let dateB = new Date(b[0]).getTime();
-            return dateA > dateB ? 1 : dateA < dateB ? -1 : 0;
-          })
-          .reverse();
-
-        ejsPageData.body = yearCollection.map((el) => el[1]).join('\n');
-        ejsPageData.article = false;
-        let [[, , firstImage]] = yearCollection;
-        ejsPageData.site.image = firstImage;
-
-        ejs.renderFile(
-          './layout/master.ejs',
-          ejsPageData,
-          {},
-          (error, pageHTML) => {
-            if (error) throw error;
-
-            fs.writeFile(
-              path.join(destPath, `${yearDir}.html`),
-              pageHTML,
-              fsWriteCallback(`Wrote HTML for ${yearDir}`)
-            );
-            if (mostRecentYear === yearDir) {
-              const fileName = path.join(destPath, 'index.html');
-
+              fse.mkdirsSync(yearDirName);
               fs.writeFile(
-                fileName,
+                path.join(yearDirName, fileName),
                 pageHTML,
-                fsWriteCallback(`Wrote HTML for index.html`)
+                fsWriteCallback(`Wrote HTML for ${cached.file}`)
               );
             }
-          }
-        );
-      }
+          );
+        }
+      );
+
+      ejsArticleData.article.isSingle = false;
+
+      // process article template for year overview page
+      ejs.renderFile(
+        './layout/partials/article.ejs',
+        ejsArticleData,
+        {},
+        (error, resultHTML) => {
+          if (error) throw error;
+
+          yearCollection.push([
+            ejsArticleData.article.date,
+            resultHTML,
+            ejsArticleData.article.image,
+          ]);
+          debug('Rendered article for year archive');
+        }
+      );
     });
+
+    if (yearCollection.length) {
+      let ejsPageData = Object.assign({}, data);
+      yearCollection = yearCollection
+        .sort((a, b) => {
+          let dateA = new Date(a[0]).getTime();
+          let dateB = new Date(b[0]).getTime();
+          return dateA > dateB ? 1 : dateA < dateB ? -1 : 0;
+        })
+        .reverse();
+
+      ejsPageData.body = yearCollection.map((el) => el[1]).join('\n');
+      ejsPageData.article = false;
+      let [[, , firstImage]] = yearCollection;
+      ejsPageData.site.image = firstImage;
+
+      ejs.renderFile(
+        './layout/master.ejs',
+        ejsPageData,
+        {},
+        (error, pageHTML) => {
+          if (error) throw error;
+
+          fs.writeFile(
+            path.join(destPath, `${yearDir}.html`),
+            pageHTML,
+            fsWriteCallback(`Wrote HTML for ${yearDir}`)
+          );
+          if (mostRecentYear === yearDir) {
+            const fileName = path.join(destPath, 'index.html');
+
+            fs.writeFile(
+              fileName,
+              pageHTML,
+              fsWriteCallback(`Wrote HTML for index.html`)
+            );
+          }
+        }
+      );
+    }
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * Static site generator generating HTML and XML (for RSS) from markdown articles using ejs templating.
+ * Static site generator generating HTML, XML (for RSS) and Markdown (for LLMs) from markdown articles using ejs templating.
  * @author  Vincent Bruijn <v@y-a-v-a.org>
  */
 const startTime = Date.now();
@@ -85,6 +85,9 @@ postcss(cssnano)
 fse.mkdirsSync(`${destPath}/feeds`);
 debug('Set up some directories');
 
+// collect all article metadata for markdown cross-references
+const allArticles = {};
+
 // read article data dir
 fs.readdir(articleSrc, (error, yearDirs) => {
   if (error) throw error;
@@ -112,6 +115,55 @@ fs.readdir(articleSrc, (error, yearDirs) => {
   let [mostRecentYear] = yearDirs;
   const rssItems = [];
   let isRssBuilt = false;
+
+  // first pass: collect all article metadata for markdown generation
+  yearDirs.forEach((yearDir) => {
+    const articleSrcYearDir = path.join(articleSrc, yearDir);
+    const files = fs.readdirSync(articleSrcYearDir);
+    allArticles[yearDir] = [];
+
+    files.forEach((file) => {
+      if (file.startsWith('_')) return;
+
+      const articleFileMd = path.join(articleSrcYearDir, file);
+      const articleMd = fs.readFileSync(articleFileMd, 'utf8');
+      const pageData = frontMatter(articleMd);
+
+      const mdFileName = file.replace(/ /g, '+');
+      const dateString = new Date(pageData.attributes.date).toLocaleString(
+        'nl-NL',
+        DATE_FORMATTER
+      );
+      const description = pageData.attributes.description || '';
+
+      allArticles[yearDir].push({
+        title: pageData.attributes.title,
+        date: pageData.attributes.date,
+        dateString,
+        image: pageData.attributes.image,
+        description,
+        shortDescription: description.length > 120
+          ? description.substring(0, 120) + '...'
+          : description,
+        markdownBody: pageData.body,
+        mdFileName,
+        yearDir,
+        file,
+      });
+    });
+
+    // sort articles by date descending
+    allArticles[yearDir].sort((a, b) => {
+      const dateA = new Date(a.date).getTime();
+      const dateB = new Date(b.date).getTime();
+      return dateA > dateB ? -1 : dateA < dateB ? 1 : 0;
+    });
+  });
+
+  debug('Collected all article metadata for markdown generation');
+
+  // generate markdown pages
+  renderMarkdownPages(yearDirs, navigationItems, mostRecentYear);
 
   // loop over year named directories
   yearDirs.forEach((yearDir, yearIndex) => {
@@ -285,6 +337,128 @@ fs.readdir(articleSrc, (error, yearDirs) => {
     });
   });
 });
+
+/**
+ * Generate markdown versions of all pages for LLM-friendly consumption.
+ * Uses the original markdown source directly with EJS templates for navigation.
+ */
+const renderMarkdownPages = (yearDirs, navigationItems, mostRecentYear) => {
+  const plainTitle = config.siteTitle.replace(/&bull;/g, '·');
+
+  const mdSiteData = {
+    plainTitle,
+    description: config.description,
+    copyright: config.copyright,
+    license: config.license,
+  };
+
+  // render individual article markdown pages
+  yearDirs.forEach((yearDir) => {
+    const articles = allArticles[yearDir];
+    const yearDirName = path.join(destPath, yearDir);
+    fse.mkdirsSync(yearDirName);
+
+    const mdNavItems = navigationItems.map((item) => ({
+      name: item.name,
+      active: item.name === yearDir,
+    }));
+
+    articles.forEach((article) => {
+      const ejsData = {
+        article,
+        site: mdSiteData,
+        navigationItems: mdNavItems,
+        yearArticles: articles,
+        currentYearDir: yearDir,
+        mostRecentYear,
+      };
+
+      ejs.renderFile(
+        './layout/markdown/article.ejs',
+        ejsData,
+        {},
+        (error, resultMd) => {
+          if (error) throw error;
+          fs.writeFile(
+            path.join(yearDirName, article.mdFileName),
+            resultMd,
+            fsWriteCallback(`Wrote Markdown for ${article.file}`)
+          );
+        }
+      );
+    });
+  });
+
+  // render year archive markdown pages
+  yearDirs.forEach((yearDir) => {
+    const articles = allArticles[yearDir];
+
+    const mdNavItems = navigationItems.map((item) => ({
+      name: item.name,
+      active: item.name === yearDir,
+    }));
+
+    const ejsData = {
+      yearDir,
+      articles,
+      site: mdSiteData,
+      navigationItems: mdNavItems,
+      mostRecentYear,
+    };
+
+    ejs.renderFile(
+      './layout/markdown/year.ejs',
+      ejsData,
+      {},
+      (error, resultMd) => {
+        if (error) throw error;
+        fs.writeFile(
+          path.join(destPath, `${yearDir}.md`),
+          resultMd,
+          fsWriteCallback(`Wrote Markdown for ${yearDir}`)
+        );
+      }
+    );
+  });
+
+  // render index.md with recent articles across all years
+  const recentArticles = yearDirs
+    .flatMap((yearDir) => allArticles[yearDir])
+    .sort((a, b) => {
+      const dateA = new Date(a.date).getTime();
+      const dateB = new Date(b.date).getTime();
+      return dateA > dateB ? -1 : dateA < dateB ? 1 : 0;
+    })
+    .slice(0, 10);
+
+  const mdNavWithCounts = navigationItems.map((item) => ({
+    name: item.name,
+    articleCount: (allArticles[item.name] || []).length,
+  }));
+
+  const ejsData = {
+    site: mdSiteData,
+    navigationItems: mdNavWithCounts,
+    recentArticles,
+    mostRecentYear,
+  };
+
+  ejs.renderFile(
+    './layout/markdown/index.ejs',
+    ejsData,
+    {},
+    (error, resultMd) => {
+      if (error) throw error;
+      fs.writeFile(
+        path.join(destPath, 'index.md'),
+        resultMd,
+        fsWriteCallback('Wrote Markdown for index.md')
+      );
+    }
+  );
+
+  debug('Generated all markdown pages');
+};
 
 const renderRssFeed = (rssItems, data) => {
   const rssItemsHTML = [];

--- a/layout/markdown/article.ejs
+++ b/layout/markdown/article.ejs
@@ -4,9 +4,9 @@
 <% if (article.description && article.description !== site.description) { %>
 
 > <%- article.description %>
-<% } %>
-
+<% } -%>
 <% if (article.image) { %>
+
 ![<%= article.title %>](/uploads/assets/<%= article.image %>)
 <% } %>
 
@@ -20,14 +20,16 @@
 
 ### Browse by year
 
-<% navigationItems.forEach(function(item) { %>* **<% if (item.active) { %><%= item.name %> (current)<% } else { %>[<%= item.name %>](/<%= item.name %>.md)<% } %>**
-<% }); %>
+<% navigationItems.forEach(function(item) { -%>
+* **<% if (item.active) { %><%= item.name %> (current)<% } else { %>[<%= item.name %>](/<%= item.name %>.md)<% } %>**
+<% }); -%>
 <% if (yearArticles && yearArticles.length > 0) { %>
 
 ### More from <%= currentYearDir %>
 
-<% yearArticles.forEach(function(a) { %>* <% if (a.title === article.title) { %><%= a.title %> (this article)<% } else { %>**[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)**<% if (a.shortDescription) { %>: <%- a.shortDescription %><% } %><% } %>
-<% }); %>
+<% yearArticles.forEach(function(a) { -%>
+* <% if (a.file === article.file) { %><%= a.title %> (this article)<% } else { %>**[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)**<% if (a.shortDescription) { %>: <%- a.shortDescription %><% } %><% } %>
+<% }); -%>
 <% } %>
 
 ---

--- a/layout/markdown/article.ejs
+++ b/layout/markdown/article.ejs
@@ -1,0 +1,35 @@
+# <%= article.title %>
+
+*<%= article.dateString %>*
+<% if (article.description && article.description !== site.description) { %>
+
+> <%- article.description %>
+<% } %>
+
+<% if (article.image) { %>
+![<%= article.title %>](/uploads/assets/<%= article.image %>)
+<% } %>
+
+<%- article.markdownBody %>
+
+---
+
+## Navigation
+
+**[<%= site.plainTitle %>](/<%= mostRecentYear %>.md)** | [RSS](/feeds/rss.xml)
+
+### Browse by year
+
+<% navigationItems.forEach(function(item) { %>* **<% if (item.active) { %><%= item.name %> (current)<% } else { %>[<%= item.name %>](/<%= item.name %>.md)<% } %>**
+<% }); %>
+<% if (yearArticles && yearArticles.length > 0) { %>
+
+### More from <%= currentYearDir %>
+
+<% yearArticles.forEach(function(a) { %>* <% if (a.title === article.title) { %><%= a.title %> (this article)<% } else { %>**[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)**<% if (a.shortDescription) { %>: <%- a.shortDescription %><% } %><% } %>
+<% }); %>
+<% } %>
+
+---
+
+*<%= site.copyright %>* | [Creative Commons BY-NC-SA 3.0](<%= site.license %>)

--- a/layout/markdown/index.ejs
+++ b/layout/markdown/index.ejs
@@ -4,15 +4,16 @@
 
 ## Recent articles
 
-<% recentArticles.forEach(function(a) { %>* **[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)** - *<%= a.dateString %>*<% if (a.shortDescription) { %>
-  <%- a.shortDescription %><% } %>
+<% recentArticles.forEach(function(a) { -%>
+* **[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)** - *<%= a.dateString %>*<% if (a.shortDescription) { %>: <%- a.shortDescription %><% } %>
 <% }); %>
 
 ---
 
 ## Browse by year
 
-<% navigationItems.forEach(function(item) { %>* **[<%= item.name %>](/<%= item.name %>.md)** - <%= item.articleCount %> article<%= item.articleCount !== 1 ? 's' : '' %>
+<% navigationItems.forEach(function(item) { -%>
+* **[<%= item.name %>](/<%= item.name %>.md)** - <%= item.articleCount %> article<%= item.articleCount !== 1 ? 's' : '' %>
 <% }); %>
 
 ---

--- a/layout/markdown/index.ejs
+++ b/layout/markdown/index.ejs
@@ -1,0 +1,27 @@
+# <%= site.plainTitle %>
+
+<%= site.description %>
+
+## Recent articles
+
+<% recentArticles.forEach(function(a) { %>* **[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)** - *<%= a.dateString %>*<% if (a.shortDescription) { %>
+  <%- a.shortDescription %><% } %>
+<% }); %>
+
+---
+
+## Browse by year
+
+<% navigationItems.forEach(function(item) { %>* **[<%= item.name %>](/<%= item.name %>.md)** - <%= item.articleCount %> article<%= item.articleCount !== 1 ? 's' : '' %>
+<% }); %>
+
+---
+
+## Related resources
+
+* **[RSS Feed](/feeds/rss.xml)**: subscribe for updates
+* **[HTML version](/)**: the full website with images and styling
+
+---
+
+*<%= site.copyright %>* | [Creative Commons BY-NC-SA 3.0](<%= site.license %>)

--- a/layout/markdown/year.ejs
+++ b/layout/markdown/year.ejs
@@ -1,0 +1,24 @@
+# <%= site.plainTitle %> - <%= yearDir %>
+
+<%= site.description %>
+
+## Articles from <%= yearDir %>
+
+<% articles.forEach(function(a) { %>* **[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)** - *<%= a.dateString %>*<% if (a.shortDescription) { %>
+  <%- a.shortDescription %><% } %>
+<% }); %>
+
+---
+
+## Navigation
+
+**[<%= site.plainTitle %>](/<%= mostRecentYear %>.md)** | [RSS](/feeds/rss.xml)
+
+### Browse by year
+
+<% navigationItems.forEach(function(item) { %>* **<% if (item.active) { %><%= item.name %> (current)<% } else { %>[<%= item.name %>](/<%= item.name %>.md)<% } %>**
+<% }); %>
+
+---
+
+*<%= site.copyright %>* | [Creative Commons BY-NC-SA 3.0](<%= site.license %>)

--- a/layout/markdown/year.ejs
+++ b/layout/markdown/year.ejs
@@ -4,8 +4,8 @@
 
 ## Articles from <%= yearDir %>
 
-<% articles.forEach(function(a) { %>* **[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)** - *<%= a.dateString %>*<% if (a.shortDescription) { %>
-  <%- a.shortDescription %><% } %>
+<% articles.forEach(function(a) { -%>
+* **[<%= a.title %>](/<%= a.yearDir %>/<%= a.mdFileName %>)** - *<%= a.dateString %>*<% if (a.shortDescription) { %>: <%- a.shortDescription %><% } %>
 <% }); %>
 
 ---
@@ -16,7 +16,8 @@
 
 ### Browse by year
 
-<% navigationItems.forEach(function(item) { %>* **<% if (item.active) { %><%= item.name %> (current)<% } else { %>[<%= item.name %>](/<%= item.name %>.md)<% } %>**
+<% navigationItems.forEach(function(item) { -%>
+* **<% if (item.active) { %><%= item.name %> (current)<% } else { %>[<%= item.name %>](/<%= item.name %>.md)<% } %>**
 <% }); %>
 
 ---


### PR DESCRIPTION
Generate .md versions of all pages alongside HTML during build:
- Individual article pages with original markdown content, navigation,
  and cross-references to other articles in the same year
- Year archive pages listing all articles with dates and descriptions
- index.md with recent articles and browse-by-year with article counts

Uses EJS templates (layout/markdown/) to wrap the original markdown
source with navigation structure, avoiding any HTML-to-markdown
conversion or regex parsing.

https://claude.ai/code/session_016i8SUjQ6gfziQoeQNup9tD